### PR TITLE
Fix to work with latest own cloud and --ocroot option

### DIFF
--- a/ocsharetools.py
+++ b/ocsharetools.py
@@ -137,7 +137,7 @@ class OCShareAPI:
         check_request(request)
         jsonfeed = request.json()
         check_status(jsonfeed)
-        return OCShare(self, **jsonfeed['ocs']['data']['element'])
+        return OCShare(self, **jsonfeed['ocs']['data'][0])
 
     def create_share(self, path, share_type, share_with=None,
                      public_upload=False, password=None, permissions=None):

--- a/ocsharetools_cli.py
+++ b/ocsharetools_cli.py
@@ -1,5 +1,6 @@
 from ocsharetools import *
 import argparse
+import path
 from datetime import datetime
 
 
@@ -129,6 +130,11 @@ def run():
         help='path to file/folder'
     )
     parser_get_shares.add_argument(
+        '--ocroot',
+        type=str,
+        help='root to owncloud (to be removed from full path)'
+    )
+    parser_get_shares.add_argument(
         '--enable-reshares',
         action='store_const',
         const=True,
@@ -157,6 +163,11 @@ def run():
         type=str,
         required=True,
         help='path to the file/folder which should be shared'
+    )
+    parser_create.add_argument(
+        '--ocroot',
+        type=str,
+        help='root to owncloud (to be removed from full path)'
     )
     parser_create.add_argument(
         '--share-type',
@@ -237,9 +248,13 @@ def run():
         import ocsharetools_gui
         ocsharetools_gui.run(args)
     try:
+        if len(args.ocroot)>0:
+            ocpath=os.path.realpath(args.path).replace(args.ocroot,'')
+        else:
+            ocpath=args.path
         if args.subparser_name == "getshares":
             shares = ocs.get_shares(
-                path=args.path,
+                path=ocpath,
                 reshares=args.enable_reshares,
                 subfiles=args.enable_subfiles
             )
@@ -250,7 +265,7 @@ def run():
             print("#%d %s %s" % (share.id, share.url, share.path))
         elif args.subparser_name == "create":
             share = ocs.create_share(
-                path=args.path,
+                path=ocpath,
                 share_type=args.share_type,
                 share_with=args.share_with,
                 public_upload=args.public_upload,

--- a/ocsharetools_cli.py
+++ b/ocsharetools_cli.py
@@ -248,12 +248,13 @@ def run():
         import ocsharetools_gui
         ocsharetools_gui.run(args)
     try:
-        if len(args.ocroot)>0:
-            ocpath=os.path.realpath(args.path)
-            if ocpath.find(args.ocroot)==0:
-                ocpath=ocpath[len(args.ocroot):]
-        else:
-            ocpath=args.path
+        if hasattr(args,"ocroot"):
+            if (args.ocroot is not None) and (len(args.ocroot)>0):
+                ocpath=os.path.realpath(args.path)
+                if ocpath.find(args.ocroot)==0:
+                    ocpath=ocpath[len(args.ocroot):]
+            else:
+                ocpath=args.path
         if args.subparser_name == "getshares":
             shares = ocs.get_shares(
                 path=ocpath,

--- a/ocsharetools_cli.py
+++ b/ocsharetools_cli.py
@@ -249,7 +249,9 @@ def run():
         ocsharetools_gui.run(args)
     try:
         if len(args.ocroot)>0:
-            ocpath=os.path.realpath(args.path).replace(args.ocroot,'')
+            ocpath=os.path.realpath(args.path)
+            if ocpath.find(args.ocroot)==0:
+                ocpath=ocpath[len(args.ocroot):]
         else:
             ocpath=args.path
         if args.subparser_name == "getshares":


### PR DESCRIPTION
The code as is wouldn't work with the latest own cloud for creating shares and I did some cargo culting to fix that.

Second, I adda an `--ocroot` option, which allows one to using share creating more in the style of `dropbox sharelink` -- it resolves links and removes ocroot in order to turn relative filesystem path into absolute owncloud path.